### PR TITLE
chore(env): add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "maurice-frank.com",
+  "install": "python3 build.py --dev",
+  "terminals": [
+    {
+      "name": "site-server",
+      "command": "python3 -m http.server 8000",
+      "description": "Serves the generated static site from the repo root. Open http://localhost:8000/docs/ to preview pages built by `python3 build.py --dev`."
+    }
+  ],
+  "ports": [
+    {
+      "name": "site",
+      "port": 8000
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment for this Python static-site generator (`build.py` renders `docs/**/content.{html,py}` into `index.html` files).

The site uses only the Python standard library — no third-party dependencies — so the config runs on Cursor's default image with no custom Dockerfile.

## `.cursor/environment.json`

- `install`: `python3 build.py --dev` — builds the static site (idempotent; git-ignored output).
- `terminals.site-server`: `python3 -m http.server 8000` — serves the site so it can be previewed at `http://localhost:8000/docs/`.
- `ports`: exposes port `8000`.

## Validation

| Check | Result |
| --- | --- |
| `python3 build.py --dev` | Builds all pages, exit 0 |
| Install idempotence | Ran twice, clean git tree |
| HTTP serve (`/docs/`, CSS, `/docs/projects/`) | All 200 |
| Browser render (homepage, projects, movie-timeline) | Fully styled, CSS + data-driven content applied |

[Homepage rendered](https://cursor.com/agents/bc-3bb47617-6846-48ca-9dfa-59c4a92cd77d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite-homepage.webp)
[Projects page rendered](https://cursor.com/agents/bc-3bb47617-6846-48ca-9dfa-59c4a92cd77d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite-projects.webp)
[Movie timeline page rendered](https://cursor.com/agents/bc-3bb47617-6846-48ca-9dfa-59c4a92cd77d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite-movie-timeline.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bb47617-6846-48ca-9dfa-59c4a92cd77d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bb47617-6846-48ca-9dfa-59c4a92cd77d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

