### PR TITLE
Move Soilytix artifacts to /soilytix/, add Bial audit, show sidebar portrait

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
         <aside class="site-sidebar">
             <div class="sidebar-top">
                 <header class="sidebar-header">
-                    <h1 class="site-title"><a href="#" style="color: inherit; text-decoration: none;">Maurice Frank</a></h1>
+                    <img class="sidebar-portrait" src="favicon.ico" alt="Maurice Frank, pixel portrait" width="72" height="72">
+                    <h1 class="site-title"><a href="./" style="color: inherit; text-decoration: none;">Maurice Frank</a></h1>
                     <div class="site-subtitle">CTO & AI Engineer</div>
                     <p class="sidebar-bio">
                         Engineering data-driven platforms, causal ML systems, and human-centric software. Based in Amsterdam.
@@ -415,7 +416,7 @@
                     <span class="section-tag">06 / LABS</span>
                 </div>
                 <p class="intro-body">
-                    Live calculators, explorable knowledge graphs, and technical investigations:
+                    Live calculators, sourced reviews, and other standalone investigations. Soilytix workshop pages live on their own overview.
                 </p>
 
                 <div class="cards-grid">
@@ -433,60 +434,32 @@
                         <div class="card-item-tags">Vanilla JS · CSS Grid · Financial Modeling</div>
                     </a>
 
-                    <!-- Open Source Claim Graphs -->
-                    <a href="./soilytix/open-source-claim-graphs.html" class="card-item">
+                    <!-- Bial Proposal Audit -->
+                    <a href="./artifacts/When%20does%20the%20body%20reach%20the%20mind%20during%20sleep.html" class="card-item">
                         <div>
                             <div class="card-item-header">
-                                <span class="card-item-title">Open-Source Claim Graph Landscape ↗</span>
-                                <span class="card-item-date">Research Lab</span>
+                                <span class="card-item-title">When does the body reach the mind during sleep? ↗</span>
+                                <span class="card-item-date">Sourced Review</span>
                             </div>
                             <p class="card-item-desc">
-                                Explorable multi-dimensional graph landscape analyzing data freshness, multilingual corpus coverage, and band guidance for agricultural verification.
+                                Doubt-driven, sourced audit of a Bial Foundation grant draft on infraslow rhythms and nocturnal hot flashes — 197 findings, a mock panel, and a revise-and-resubmit verdict.
                             </p>
                         </div>
-                        <div class="card-item-tags">Knowledge Graphs · Interactive Visualization</div>
+                        <div class="card-item-tags">Grant Review · Psychophysiology · Adversarial Audit</div>
                     </a>
 
-                    <!-- AI Usage Report -->
-                    <a href="./soilytix/aiusage-report-2026-08-04.html" class="card-item">
+                    <!-- Soilytix overview (collection, not individual artifacts) -->
+                    <a href="./soilytix/" class="card-item">
                         <div>
                             <div class="card-item-header">
-                                <span class="card-item-title">LLM Usage & Token Spend Analysis ↗</span>
-                                <span class="card-item-date">Engineering Audit</span>
+                                <span class="card-item-title">Soilytix workshop ↗</span>
+                                <span class="card-item-date">Overview</span>
                             </div>
                             <p class="card-item-desc">
-                                Comprehensive audit of inference spend, prompt caching efficiency, token unit costs, and latency benchmarks across production model providers.
+                                Architecture maps, product mocks, domain comics, and internal research from the soil-intelligence platform — collected on a dedicated index.
                             </p>
                         </div>
-                        <div class="card-item-tags">LLMOps · Cost Optimization · Metrics</div>
-                    </a>
-
-                    <!-- Pathogen Pressure Mock -->
-                    <a href="./soilytix/pathogen-pressure-mock.html" class="card-item">
-                        <div>
-                            <div class="card-item-header">
-                                <span class="card-item-title">Pathogen Pressure & Parcel Risk Modeling ↗</span>
-                                <span class="card-item-date">Spatial Interface</span>
-                            </div>
-                            <p class="card-item-desc">
-                                High-precision geospatial interface modeling pathogen propagation vectors across irregular farm parcels with cohort risk distributions.
-                            </p>
-                        </div>
-                        <div class="card-item-tags">SVG Vector Analytics · Spatial UI</div>
-                    </a>
-
-                    <!-- The Life of a Soil Sample -->
-                    <a href="./soilytix/the-life-of-a-soil-sample.html" class="card-item">
-                        <div>
-                            <div class="card-item-header">
-                                <span class="card-item-title">The Life of a Soil Sample ↗</span>
-                                <span class="card-item-date">Visual Narrative</span>
-                            </div>
-                            <p class="card-item-desc">
-                                Illustrated narrative detailing the journey of physical soil samples from agricultural fields through wet lab assays into digital intelligence.
-                            </p>
-                        </div>
-                        <div class="card-item-tags">Science Communication · Comic</div>
+                        <div class="card-item-tags">Soilytix · Workshop · Prototypes</div>
                     </a>
                 </div>
             </section>

--- a/soilytix/index.html
+++ b/soilytix/index.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Soilytix workshop — Maurice Frank</title>
+    <meta name="description" content="Overview of Soilytix workshop artifacts: architecture maps, product mocks, domain comics, and internal research.">
+    <link rel="icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+
+    <div class="site-wrapper">
+        <aside class="site-sidebar">
+            <div class="sidebar-top">
+                <header class="sidebar-header">
+                    <img class="sidebar-portrait" src="../favicon.ico" alt="Maurice Frank, pixel portrait" width="72" height="72">
+                    <h1 class="site-title"><a href="../" style="color: inherit; text-decoration: none;">Maurice Frank</a></h1>
+                    <div class="site-subtitle">Soilytix workshop</div>
+                    <p class="sidebar-bio">
+                        Architecture, product mocks, and research from the soil-intelligence platform. These pages are working documents, not the public product.
+                    </p>
+                </header>
+
+                <nav class="sidebar-nav" aria-label="Section navigation">
+                    <div class="nav-label">Index</div>
+                    <ul class="nav-list">
+                        <li class="nav-item"><a href="#platform" class="nav-link active">01 / Platform</a></li>
+                        <li class="nav-item"><a href="#product" class="nav-link">02 / Product &amp; domain</a></li>
+                        <li class="nav-item"><a href="#research" class="nav-link">03 / Research &amp; ops</a></li>
+                    </ul>
+                </nav>
+            </div>
+
+            <div class="sidebar-footer">
+                <div class="nav-label">Elsewhere</div>
+                <div class="social-links">
+                    <a href="../" class="social-link">← Home</a>
+                    <a href="https://soilytix.com/" target="_blank" rel="noopener noreferrer" class="social-link">soilytix.com ↗</a>
+                </div>
+            </div>
+        </aside>
+
+        <main class="site-main">
+            <section id="platform" class="content-section">
+                <div class="section-header">
+                    <h2 class="section-title">Platform architecture</h2>
+                    <span class="section-tag">01 / WORKSHOP</span>
+                </div>
+                <p class="intro-body">
+                    Three dimensions on one canvas: what the platform can do, the engineering work that builds it, and the products those capabilities could ladder into.
+                </p>
+
+                <div class="cards-grid">
+                    <a href="./overview-map.html" class="card-item">
+                        <div>
+                            <div class="card-item-header">
+                                <span class="card-item-title">Overview map ↗</span>
+                                <span class="card-item-date">Canvas</span>
+                            </div>
+                            <p class="card-item-desc">
+                                Capabilities, engineering work, and product directions on a single canvas. Cell colour names the capability; intensity is how much of it is in play.
+                            </p>
+                        </div>
+                        <div class="card-item-tags">Architecture · Capability map</div>
+                    </a>
+
+                    <a href="./capabilities.html" class="card-item">
+                        <div>
+                            <div class="card-item-header">
+                                <span class="card-item-title">Capabilities ↗</span>
+                                <span class="card-item-date">Dimension 1</span>
+                            </div>
+                            <p class="card-item-desc">
+                                Five layers that describe what the platform can do, independent of any one product. Three are foundational; two are high-leverage differentiation axes.
+                            </p>
+                        </div>
+                        <div class="card-item-tags">Platform · Capability model</div>
+                    </a>
+
+                    <a href="./engineering-work.html" class="card-item">
+                        <div>
+                            <div class="card-item-header">
+                                <span class="card-item-title">Engineering work packages ↗</span>
+                                <span class="card-item-date">Dimension 2</span>
+                            </div>
+                            <p class="card-item-desc">
+                                Fourteen concrete pieces of engineering that together build the five capabilities — definition clarity, difficulty, risk, and current maturity.
+                            </p>
+                        </div>
+                        <div class="card-item-tags">Delivery · Work packages</div>
+                    </a>
+
+                    <a href="./prototypes.html" class="card-item">
+                        <div>
+                            <div class="card-item-header">
+                                <span class="card-item-title">Product prototypes ↗</span>
+                                <span class="card-item-date">Dimension 3</span>
+                            </div>
+                            <p class="card-item-desc">
+                                Six product directions the work could ladder up to: who buys, what they get, known demand, blockers, and which capability layers each one needs.
+                            </p>
+                        </div>
+                        <div class="card-item-tags">Product · Directions</div>
+                    </a>
+
+                    <a href="./six-month-engineering-effort.html" class="card-item">
+                        <div>
+                            <div class="card-item-header">
+                                <span class="card-item-title">Six-month engineering effort ↗</span>
+                                <span class="card-item-date">May–Nov 2026</span>
+                            </div>
+                            <p class="card-item-desc">
+                                Four-lane roadmap across domain model, commercial platform, cloud surface, and the Hamburg on-premise tier — read left to right through Q2, Q3, and Q4 entry.
+                            </p>
+                        </div>
+                        <div class="card-item-tags">Roadmap · Delivery</div>
+                    </a>
+                </div>
+            </section>
+
+            <section id="product" class="content-section">
+                <div class="section-header">
+                    <h2 class="section-title">Product &amp; domain</h2>
+                    <span class="section-tag">02 / MOCKS</span>
+                </div>
+                <p class="intro-body">
+                    Farmer-facing interfaces and a domain comic that walks a soil sample from field to digital intelligence.
+                </p>
+
+                <div class="cards-grid">
+                    <a href="./pathogen-pressure-mock.html" class="card-item">
+                        <div>
+                            <div class="card-item-header">
+                                <span class="card-item-title">Pathogen pressure — Val del Pino ↗</span>
+                                <span class="card-item-date">Spatial Interface</span>
+                            </div>
+                            <p class="card-item-desc">
+                                Draft pathogen-pressure profile for an Iberian SHD olive estate: parcel risk, contributor breakdown, and a measurement-first reading of the asset.
+                            </p>
+                        </div>
+                        <div class="card-item-tags">SVG · Spatial UI · Olive</div>
+                    </a>
+
+                    <a href="./2026-05-22%20%E2%80%94%20SLM%20co-design%20mock%20%E2%80%94%20draft.html" class="card-item">
+                        <div>
+                            <div class="card-item-header">
+                                <span class="card-item-title">SLM co-design mock ↗</span>
+                                <span class="card-item-date">Draft · 2026-05-22</span>
+                            </div>
+                            <p class="card-item-desc">
+                                Co-design mock for the SLM / Iberia spine: asset views, operator rollup, and an analytical template generalised from a walnut and almond case.
+                            </p>
+                        </div>
+                        <div class="card-item-tags">Product mock · Portfolio</div>
+                    </a>
+
+                    <a href="./the-life-of-a-soil-sample.html" class="card-item">
+                        <div>
+                            <div class="card-item-header">
+                                <span class="card-item-title">The Life of a Soil Sample ↗</span>
+                                <span class="card-item-date">Domain comic v0.3</span>
+                            </div>
+                            <p class="card-item-desc">
+                                Step-by-step lineage told from the sample’s point of view. Each panel is anchored to a domain aggregate, lifecycle rule, or invariant.
+                            </p>
+                        </div>
+                        <div class="card-item-tags">Science communication · Comic</div>
+                    </a>
+                </div>
+            </section>
+
+            <section id="research" class="content-section">
+                <div class="section-header">
+                    <h2 class="section-title">Research &amp; operations</h2>
+                    <span class="section-tag">03 / LABS</span>
+                </div>
+                <p class="intro-body">
+                    Vendor surveys, spend audits, and tooling comparisons used while building the platform.
+                </p>
+
+                <div class="cards-grid">
+                    <a href="./open-source-claim-graphs.html" class="card-item">
+                        <div>
+                            <div class="card-item-header">
+                                <span class="card-item-title">Open-source claim graphs ↗</span>
+                                <span class="card-item-date">Vendor survey</span>
+                            </div>
+                            <p class="card-item-desc">
+                                Explorable landscape of self-hostable prior art between filing papers and synthesising across them — ten bands, ~150 projects, with freshness and language guidance.
+                            </p>
+                        </div>
+                        <div class="card-item-tags">Knowledge graphs · Prior art</div>
+                    </a>
+
+                    <a href="./aiusage-report-2026-08-04.html" class="card-item">
+                        <div>
+                            <div class="card-item-header">
+                                <span class="card-item-title">LLM spend by agent ↗</span>
+                                <span class="card-item-date">2026-05-07 → 08-04</span>
+                            </div>
+                            <p class="card-item-desc">
+                                Token spend, caching efficiency, and unit-cost benchmarks across production model providers for the Soilytix engineering agents.
+                            </p>
+                        </div>
+                        <div class="card-item-tags">LLMOps · Cost · Metrics</div>
+                    </a>
+
+                    <a href="./meeting-notes.html" class="card-item">
+                        <div>
+                            <div class="card-item-header">
+                                <span class="card-item-title">AI meeting notetaker matrix ↗</span>
+                                <span class="card-item-date">Feature comparison</span>
+                            </div>
+                            <p class="card-item-desc">
+                                Filterable comparison of thirteen meeting-notetaker tools across hard constraints, pricing, capture, privacy, and intelligence features.
+                            </p>
+                        </div>
+                        <div class="card-item-tags">Tooling · Comparison</div>
+                    </a>
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const sections = document.querySelectorAll('.content-section');
+            const navLinks = document.querySelectorAll('.sidebar-nav .nav-link');
+
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        const id = entry.target.getAttribute('id');
+                        navLinks.forEach(link => {
+                            if (link.getAttribute('href') === `#${id}`) {
+                                link.classList.add('active');
+                            } else {
+                                link.classList.remove('active');
+                            }
+                        });
+                    }
+                });
+            }, { rootMargin: '-20% 0px -70% 0px' });
+
+            sections.forEach(s => observer.observe(s));
+        });
+    </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -81,6 +81,18 @@ body {
   margin-bottom: var(--space-xl);
 }
 
+.sidebar-portrait {
+  display: block;
+  width: 4.5rem;
+  height: 4.5rem;
+  object-fit: cover;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+  border: 1px solid var(--border-hairline);
+  margin-bottom: var(--space-md);
+  background: var(--bg-subtle);
+}
+
 .site-title {
   font-size: 1.65rem;
   font-weight: 700;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Moves individual Soilytix workshop pages off the homepage into a dedicated overview at `/soilytix/`, wires the sourced Bial proposal audit into Interactive Artifacts, and shows the pixel favicon above the name in the sidebar.

## Changes

- Homepage Artifacts no longer links claim graphs, LLM spend, pathogen pressure, or the soil-sample comic directly.
- `/soilytix/` is an overview of all workshop pages (platform, product/domain, research/ops), with a single collection card on the homepage pointing there.
- New artifact `When does the body reach the mind during sleep` is listed in Interactive Artifacts.
- Sidebar shows `favicon.ico` as a portrait above the name on the homepage and the Soilytix overview.

## Verification

Homepage sidebar portrait, the three artifacts cards, `/soilytix/` overview, and the Bial audit page all load as expected.

[Homepage sidebar with pixel portrait above the name](https://cursor.com/agents/bc-a0a35df7-683c-4325-9bc1-82e5f05f6977/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_sidebar_portrait.webp)
[Homepage artifacts: tax simulator, Bial audit, Soilytix workshop overview](https://cursor.com/agents/bc-a0a35df7-683c-4325-9bc1-82e5f05f6977/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_artifacts_cards.webp)
[Soilytix overview page grouping workshop artifacts](https://cursor.com/agents/bc-a0a35df7-683c-4325-9bc1-82e5f05f6977/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsoilytix_overview.webp)
[sidebar_portrait_artifacts_and_soilytix_overview.mp4](https://cursor.com/agents/bc-a0a35df7-683c-4325-9bc1-82e5f05f6977/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar_portrait_artifacts_and_soilytix_overview.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0a35df7-683c-4325-9bc1-82e5f05f6977?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0a35df7-683c-4325-9bc1-82e5f05f6977&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

