### PR TITLE
Unify type, refresh software, and extend photography

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,59 +228,103 @@
                 </div>
 
                 <div class="software-list">
-                    <a href="https://github.com/gitHBDX/dash-prometheus" target="_blank" rel="noopener noreferrer" class="software-item">
+                    <a href="https://github.com/morris-frank/aiusage" target="_blank" rel="noopener noreferrer" class="software-item">
                         <div class="software-left">
                             <span class="software-name">
-                                dash-prometheus
+                                aiusage
                                 <span class="gh-pill">GitHub ↗</span>
                             </span>
-                            <span class="software-summary">Performance metrics and Prometheus exporter for Plotly Dash applications.</span>
+                            <span class="software-summary">CLI that reads platform billing APIs and reports AI spend by account, key, model, and workspace.</span>
                         </div>
-                        <span class="software-tech">Python · Plotly · Prometheus</span>
+                        <span class="software-tech">TypeScript · CLI</span>
                     </a>
 
-                    <a href="https://github.com/gitHBDX/anndata-cache" target="_blank" rel="noopener noreferrer" class="software-item">
+                    <a href="https://github.com/morris-frank/obsidian-typst" target="_blank" rel="noopener noreferrer" class="software-item">
                         <div class="software-left">
                             <span class="software-name">
-                                anndata-cache
+                                obsidian-typst
                                 <span class="gh-pill">GitHub ↗</span>
                             </span>
-                            <span class="software-summary">Shared-process in-memory caching store for large AnnData genomic matrices.</span>
+                            <span class="software-summary">Obsidian plugin to preview and compile Typst, and export Markdown notes to PDF.</span>
                         </div>
-                        <span class="software-tech">Python · pyArrow · IPC</span>
+                        <span class="software-tech">TypeScript · Obsidian · Typst</span>
                     </a>
 
-                    <a href="https://github.com/morris-frank/BarTasks" target="_blank" rel="noopener noreferrer" class="software-item">
+                    <a href="https://github.com/morris-frank/ask-maurice" target="_blank" rel="noopener noreferrer" class="software-item">
                         <div class="software-left">
                             <span class="software-name">
-                                BarTasks
+                                ask-maurice
                                 <span class="gh-pill">GitHub ↗</span>
                             </span>
-                            <span class="software-summary">Lightweight, distraction-free task management utility that lives in the macOS menu bar.</span>
+                            <span class="software-summary">Slack doppelgänger that answers in Maurice’s voice, grounded in the shared Soilytix vault.</span>
                         </div>
-                        <span class="software-tech">macOS · Swift · SwiftUI</span>
+                        <span class="software-tech">Python · Slack · Agents</span>
                     </a>
 
-                    <a href="https://github.com/morris-frank/letterboxd-ratings-for-cineville" target="_blank" rel="noopener noreferrer" class="software-item">
+                    <a href="https://github.com/morris-frank/call-bases" target="_blank" rel="noopener noreferrer" class="software-item">
                         <div class="software-left">
                             <span class="software-name">
-                                Letterboxd for Cineville
+                                call-bases
                                 <span class="gh-pill">GitHub ↗</span>
                             </span>
-                            <span class="software-summary">Browser extension displaying Letterboxd film community scores on Cineville movie pages.</span>
+                            <span class="software-summary">Streams a genome base by base at human scale — a year of DNA at about 101 bases per second.</span>
                         </div>
-                        <span class="software-tech">Chrome · WebExtensions · JS</span>
+                        <span class="software-tech">HTML · Node · Genomics</span>
                     </a>
 
-                    <a href="https://clue-to-drip.netlify.app/" target="_blank" rel="noopener noreferrer" class="software-item">
+                    <a href="https://github.com/morris-frank/agent-plugin-template" target="_blank" rel="noopener noreferrer" class="software-item">
                         <div class="software-left">
                             <span class="software-name">
-                                Clue to Drip
-                                <span class="gh-pill">Live Web ↗</span>
+                                agent-plugin-template
+                                <span class="gh-pill">GitHub ↗</span>
                             </span>
-                            <span class="software-summary">Client-side privacy-first data converter migrating health tracking records into open-source Drip.</span>
+                            <span class="software-summary">Canonical marketplace template for Claude, Codex, and Cursor plugins from one repository.</span>
                         </div>
-                        <span class="software-tech">AlpineJS · Static Web</span>
+                        <span class="software-tech">JavaScript · Claude · Cursor · Codex</span>
+                    </a>
+
+                    <a href="https://github.com/morris-frank/chrome-time-clock" target="_blank" rel="noopener noreferrer" class="software-item">
+                        <div class="software-left">
+                            <span class="software-name">
+                                chrome-time-clock
+                                <span class="gh-pill">GitHub ↗</span>
+                            </span>
+                            <span class="software-summary">Infers workday hours from Chrome, Chromium, or Brave history and plots the resulting timeline.</span>
+                        </div>
+                        <span class="software-tech">Python · CLI</span>
+                    </a>
+
+                    <a href="https://github.com/morris-frank/QLGIS" target="_blank" rel="noopener noreferrer" class="software-item">
+                        <div class="software-left">
+                            <span class="software-name">
+                                QLGIS
+                                <span class="gh-pill">GitHub ↗</span>
+                            </span>
+                            <span class="software-summary">macOS Quick Look previews for PMTiles, GeoTIFF, and GeoJSON.</span>
+                        </div>
+                        <span class="software-tech">Swift · TypeScript · macOS</span>
+                    </a>
+
+                    <a href="https://github.com/morris-frank/notion-md-to-pptx" target="_blank" rel="noopener noreferrer" class="software-item">
+                        <div class="software-left">
+                            <span class="software-name">
+                                notion-md-to-pptx
+                                <span class="gh-pill">GitHub ↗</span>
+                            </span>
+                            <span class="software-summary">Converts Notion-style Markdown into themed PowerPoint decks.</span>
+                        </div>
+                        <span class="software-tech">JavaScript · CLI</span>
+                    </a>
+
+                    <a href="https://github.com/morris-frank/clue-to-drip" target="_blank" rel="noopener noreferrer" class="software-item">
+                        <div class="software-left">
+                            <span class="software-name">
+                                clue-to-drip
+                                <span class="gh-pill">GitHub ↗</span>
+                            </span>
+                            <span class="software-summary">Client-side converter from Clue health exports into CSV for open-source Drip.</span>
+                        </div>
+                        <span class="software-tech">JavaScript · Static Web</span>
                     </a>
 
                     <a href="https://collegiumacademicum.de" target="_blank" rel="noopener noreferrer" class="software-item">
@@ -324,6 +368,19 @@
                         <p class="media-card-desc">Visual vignette capturing street cats in Istanbul (Jan 2023). Music: Altın Gün (<em>Kolbastı</em>). Filmed on Pixel 7, edited in DaVinci Resolve.</p>
                         <video controls preload="metadata" poster="https://cdn.maurice-frank.com/morris-media/KediIstanbul.jpg">
                             <source src="https://cdn.maurice-frank.com/morris-media/KediIstanbul.mp4" type="video/mp4">
+                            Your browser does not support HTML5 video.
+                        </video>
+                    </div>
+
+                    <!-- Video Card: Eating Hooks -->
+                    <div class="media-card full-width">
+                        <div class="media-card-top">
+                            <span class="media-card-title">Eating Hooks</span>
+                            <span class="media-card-tag">Video · 2020</span>
+                        </div>
+                        <p class="media-card-desc">Most likely the first high-quality, non-experimental, fully AI-generated music video in this form, dating to 2020.</p>
+                        <video controls preload="metadata" poster="https://cdn.maurice-frank.com/morris-media/Eating%20Hooks.jpg">
+                            <source src="https://cdn.maurice-frank.com/morris-media/Eating%20Hooks.mp4" type="video/mp4">
                             Your browser does not support HTML5 video.
                         </video>
                     </div>
@@ -385,26 +442,99 @@
                     </div>
                 </div>
 
-                <!-- Minimal Photography Gallery -->
+                <!-- Photography scroller -->
                 <div style="margin-top: var(--space-xl);">
-                    <div class="nav-label" style="margin-bottom: var(--space-xs);">Photography & Mountains</div>
-                    <div class="photo-gallery">
-                        <figure class="photo-item">
-                            <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20220904_073653-02.webp" alt="Sunrise at Fletschhorn" loading="lazy">
-                            <figcaption>Sunrise at Fletschhorn</figcaption>
-                        </figure>
-                        <figure class="photo-item">
-                            <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20240806_064438578.RAW-02.ORIGINAL.webp" alt="Matterhorn summit" loading="lazy">
-                            <figcaption>Matterhorn summit</figcaption>
-                        </figure>
-                        <figure class="photo-item">
-                            <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20230726_185216099.webp" alt="Mont Blanc" loading="lazy">
-                            <figcaption>Mont Blanc</figcaption>
-                        </figure>
-                        <figure class="photo-item">
-                            <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20180210_162716.webp" alt="Bothe Koshi valley, Khumbu" loading="lazy">
-                            <figcaption>Bothe Koshi valley · खुम्बु</figcaption>
-                        </figure>
+                    <div class="nav-label" style="margin-bottom: var(--space-xs);">Photography &amp; Mountains</div>
+                    <div class="photo-scroller-wrap">
+                        <div class="photo-scroller" id="photo-scroller" role="list" aria-label="Photograph gallery, scroll sideways">
+                            <button type="button" class="photo-item" role="listitem" data-caption="Sunrise at Fletschhorn" aria-label="View Sunrise at Fletschhorn full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20220904_073653-02.webp" alt="Sunrise at Fletschhorn" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="Matterhorn summit" aria-label="View Matterhorn summit full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20240806_064438578.RAW-02.ORIGINAL.webp" alt="Matterhorn summit" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="Mont Blanc" aria-label="View Mont Blanc full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20230726_185216099.webp" alt="Mont Blanc" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="Bothe Koshi valley · खुम्बु" aria-label="View Bothe Koshi valley full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20180210_162716.webp" alt="Bothe Koshi valley, Khumbu" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="August 2017" aria-label="View photograph, August 2017, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/P1080504.webp" alt="Photograph, August 2017" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="September 2017" aria-label="View photograph, September 2017, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/P1090027.webp" alt="Photograph, September 2017" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="January 2018" aria-label="View photograph, January 2018, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20180103_105745.webp" alt="Photograph, January 2018" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="January 2018" aria-label="View photograph, January 2018, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20180124_134233.webp" alt="Photograph, January 2018" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="January 2018" aria-label="View photograph, January 2018, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20180125_080130.webp" alt="Photograph, January 2018" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="November 2019" aria-label="View photograph, November 2019, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/DSC03185.webp" alt="Photograph, November 2019" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="November 2019" aria-label="View photograph, November 2019, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/DSC03265.webp" alt="Photograph, November 2019" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="August 2022" aria-label="View photograph, August 2022, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20220815_124755-01.webp" alt="Photograph, August 2022" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="August 2022" aria-label="View photograph, August 2022, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20220816_080158-01.webp" alt="Photograph, August 2022" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="August 2022" aria-label="View photograph, August 2022, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20220816_101549-01.webp" alt="Photograph, August 2022" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="August 2022" aria-label="View photograph, August 2022, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20220820_155549-01.webp" alt="Photograph, August 2022" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="September 2022" aria-label="View photograph, September 2022, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20220903_092307-01.webp" alt="Photograph, September 2022" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="December 2022" aria-label="View photograph, December 2022, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20221210_100808728.webp" alt="Photograph, December 2022" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="August 2023" aria-label="View photograph, August 2023, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20230803_063316867.webp" alt="Photograph, August 2023" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="September 2023" aria-label="View photograph, September 2023, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20230920_164213120.webp" alt="Photograph, September 2023" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="August 2024" aria-label="View photograph, August 2024, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20240804_042024715.RAW-02.ORIGINAL.webp" alt="Photograph, August 2024" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="August 2024" aria-label="View photograph, August 2024, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20240806_043128001.RAW-02.ORIGINAL.webp" alt="Photograph, August 2024" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="August 2024" aria-label="View photograph, August 2024, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20240806_051812332.RAW-02.ORIGINAL.webp" alt="Photograph, August 2024" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="October 2024" aria-label="View photograph, October 2024, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20241008_134642745.RAW-02.ORIGINAL.webp" alt="Photograph, October 2024" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="December 2024" aria-label="View photograph, December 2024, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20241208_133902765.RAW-02.ORIGINAL.webp" alt="Photograph, December 2024" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="December 2024" aria-label="View photograph, December 2024, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20241208_134657020.RAW-02.ORIGINAL.webp" alt="Photograph, December 2024" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="December 2024" aria-label="View photograph, December 2024, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20241208_134831613.RAW-02.ORIGINAL.webp" alt="Photograph, December 2024" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="December 2024" aria-label="View photograph, December 2024, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20241208_134950226.RAW-02.ORIGINAL.webp" alt="Photograph, December 2024" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="December 2024" aria-label="View photograph, December 2024, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20241208_140609812.RAW-02.ORIGINAL.webp" alt="Photograph, December 2024" loading="lazy">
+                            </button>
+                            <button type="button" class="photo-item" role="listitem" data-caption="December 2024" aria-label="View photograph, December 2024, full screen">
+                                <img src="https://cdn.maurice-frank.com/morris-media/photography/PXL_20241208_141227369.RAW-02.ORIGINAL.webp" alt="Photograph, December 2024" loading="lazy">
+                            </button>
+                        </div>
                     </div>
                 </div>
             </section>
@@ -472,7 +602,7 @@
                 </div>
 
                 <p style="margin-bottom: var(--space-md);">
-                    Set in <em>Instrument Sans</em> and <em>JetBrains Mono</em>. Built with zero tracking, zero cookies, and zero analytics.
+                    Set in <em>Instrument Sans</em>. Built with zero tracking, zero cookies, and zero analytics.
                 </p>
 
                 <div class="colophon-legal">
@@ -497,7 +627,17 @@
         </main>
     </div>
 
-    <!-- Scrollspy Navigator -->
+    <dialog class="photo-lightbox" id="photo-lightbox" aria-label="Full-screen photograph">
+        <button type="button" class="photo-lightbox-btn photo-lightbox-close" data-lightbox-close aria-label="Close">×</button>
+        <button type="button" class="photo-lightbox-btn photo-lightbox-prev" data-lightbox-prev aria-label="Previous photograph">‹</button>
+        <div class="photo-lightbox-inner">
+            <img src="" alt="">
+            <div class="photo-lightbox-caption"></div>
+        </div>
+        <button type="button" class="photo-lightbox-btn photo-lightbox-next" data-lightbox-next aria-label="Next photograph">›</button>
+    </dialog>
+
+    <!-- Scrollspy Navigator + photography lightbox -->
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const sections = document.querySelectorAll('.content-section, .colophon-section');
@@ -519,6 +659,61 @@
             }, { rootMargin: '-20% 0px -70% 0px' });
 
             sections.forEach(s => observer.observe(s));
+
+            const photos = Array.from(document.querySelectorAll('.photo-item'));
+            const lightbox = document.getElementById('photo-lightbox');
+            const lightboxImg = lightbox.querySelector('img');
+            const lightboxCap = lightbox.querySelector('.photo-lightbox-caption');
+            let current = 0;
+
+            function showPhoto(index) {
+                current = (index + photos.length) % photos.length;
+                const item = photos[current];
+                const img = item.querySelector('img');
+                lightboxImg.src = img.currentSrc || img.src;
+                lightboxImg.alt = img.alt;
+                lightboxCap.textContent = item.dataset.caption || img.alt || '';
+            }
+
+            function openPhoto(index) {
+                showPhoto(index);
+                if (typeof lightbox.showModal === 'function') {
+                    lightbox.showModal();
+                } else {
+                    lightbox.setAttribute('open', '');
+                }
+            }
+
+            function closeLightbox() {
+                if (typeof lightbox.close === 'function' && lightbox.open) {
+                    lightbox.close();
+                } else {
+                    lightbox.removeAttribute('open');
+                }
+            }
+
+            photos.forEach((item, index) => {
+                item.addEventListener('click', () => openPhoto(index));
+            });
+
+            lightbox.querySelector('[data-lightbox-close]').addEventListener('click', closeLightbox);
+            lightbox.querySelector('[data-lightbox-prev]').addEventListener('click', () => showPhoto(current - 1));
+            lightbox.querySelector('[data-lightbox-next]').addEventListener('click', () => showPhoto(current + 1));
+
+            lightbox.addEventListener('click', (event) => {
+                if (event.target === lightbox) closeLightbox();
+            });
+
+            document.addEventListener('keydown', (event) => {
+                if (!lightbox.open) return;
+                if (event.key === 'ArrowLeft') {
+                    event.preventDefault();
+                    showPhoto(current - 1);
+                } else if (event.key === 'ArrowRight') {
+                    event.preventDefault();
+                    showPhoto(current + 1);
+                }
+            });
         });
     </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
   Maurice Frank — Design System & Styles
   Aesthetic: Swiss Minimalist UI + Structured Editorial UX
-  Typography: Instrument Sans & JetBrains Mono
+  Typography: Instrument Sans
   Palette: Pure monochrome, crisp hairline geometry, high-density clarity
 */
 
@@ -606,42 +606,180 @@ video {
   display: block;
 }
 
-/* Photography Grid */
-.photo-gallery {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: var(--space-sm);
-  margin-top: var(--space-md);
+/* Photography scroller */
+.photo-scroller-wrap {
+  position: relative;
+  margin-top: var(--space-sm);
+}
+
+.photo-scroller-wrap::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 56px;
+  height: 100%;
+  pointer-events: none;
+  background: linear-gradient(to right, transparent, var(--bg-app));
+}
+
+.photo-scroller {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x proximity;
+  scroll-padding-inline: 0;
+  padding: 0 0 6px;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-medium) transparent;
+}
+
+.photo-scroller::-webkit-scrollbar {
+  height: 6px;
+}
+
+.photo-scroller::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.photo-scroller::-webkit-scrollbar-thumb {
+  background: var(--border-medium);
+  border-radius: 3px;
 }
 
 .photo-item {
+  flex: 0 0 auto;
+  scroll-snap-align: start;
   border: 1px solid var(--border-hairline);
   border-radius: 3px;
   overflow: hidden;
-  background: var(--bg-surface);
+  background: var(--bg-subtle);
+  padding: 0;
+  margin: 0;
+  cursor: zoom-in;
+  appearance: none;
+  -webkit-appearance: none;
+  font: inherit;
+  line-height: 0;
+  color: inherit;
+}
+
+.photo-item:hover img,
+.photo-item:focus-visible img {
+  opacity: 0.9;
+}
+
+.photo-item:focus-visible {
+  outline: 2px solid var(--text-primary);
+  outline-offset: 2px;
 }
 
 .photo-item img {
-  width: 100%;
-  height: 140px;
-  object-fit: cover;
   display: block;
-  transition: var(--transition-fast);
+  height: 152px;
+  width: auto;
+  max-width: 240px;
+  object-fit: cover;
+  transition: opacity 0.15s ease;
 }
 
-.photo-item:hover img {
-  opacity: 0.92;
+/* Full-screen photo lightbox */
+.photo-lightbox {
+  position: fixed;
+  inset: 0;
+  margin: 0;
+  border: none;
+  padding: 0;
+  width: 100vw;
+  height: 100vh;
+  max-width: 100vw;
+  max-height: 100vh;
+  background: rgba(10, 10, 10, 0.96);
+  color: #f5f5f5;
 }
 
-.photo-item figcaption {
-  padding: 5px 8px;
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  color: var(--text-secondary);
-  border-top: 1px solid var(--border-hairline);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.photo-lightbox::backdrop {
+  background: rgba(0, 0, 0, 0.92);
+}
+
+.photo-lightbox-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 48px 56px 40px;
+  box-sizing: border-box;
+}
+
+.photo-lightbox img {
+  width: auto;
+  height: auto;
+  max-width: min(96vw, 1400px);
+  max-height: calc(100vh - 96px);
+  object-fit: contain;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  margin: 0;
+}
+
+.photo-lightbox-caption {
+  margin-top: 12px;
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  color: rgba(255, 255, 255, 0.72);
+  min-height: 1.2em;
+}
+
+.photo-lightbox-btn {
+  position: absolute;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+  padding: 8px;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.photo-lightbox-btn:hover,
+.photo-lightbox-btn:focus-visible {
+  color: #ffffff;
+}
+
+.photo-lightbox-close {
+  top: 12px;
+  right: 16px;
+  font-size: 1.5rem;
+}
+
+.photo-lightbox-prev,
+.photo-lightbox-next {
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 2rem;
+  padding: 16px 12px;
+}
+
+.photo-lightbox-prev { left: 4px; }
+.photo-lightbox-next { right: 4px; }
+
+@media (max-width: 600px) {
+  .photo-lightbox-inner {
+    padding: 40px 12px 32px;
+  }
+  .photo-lightbox-prev,
+  .photo-lightbox-next {
+    font-size: 1.5rem;
+    padding: 12px 6px;
+  }
 }
 
 /* Colophon */

--- a/tokens.css
+++ b/tokens.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=JetBrains+Mono:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap');
 
 :root {
   --bg-app: #FFFFFF;
@@ -16,7 +16,7 @@
   --border-strong: #111111;
 
   --font-sans: "Instrument Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --font-mono: var(--font-sans);
 
   --sidebar-width: 280px;
   --content-max-width: 800px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Unify the site on Instrument Sans, replace the selected software list, and extend the photography section with a scroller and full-screen view.

## Changes
- Drop JetBrains Mono so Instrument Sans is the only loaded typeface.
- Replace the selected software list with the current GitHub projects plus Collegium Academicum and Ackersyndikat.
- Photography becomes a horizontal scroller of all 29 available `.webp` files, with click-to-fullscreen and keyboard next/previous.
- Add *Eating Hooks* (2020), noted as likely the first high-quality, non-experimental, fully AI-generated music video in this form.

## Verification
Desktop walkthrough (software list, Eating Hooks, photo scroller, lightbox, colophon):

[software_photos_media_walkthrough.mp4](https://cursor.com/agents/bc-55773b13-5f3c-4b4b-b63f-077852b97215/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsoftware_photos_media_walkthrough.mp4)

[Selected software list](https://cursor.com/agents/bc-55773b13-5f3c-4b4b-b63f-077852b97215/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsoftware_list.webp)
[Eating Hooks video card](https://cursor.com/agents/bc-55773b13-5f3c-4b4b-b63f-077852b97215/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feating_hooks_video.webp)
[Photography scroller](https://cursor.com/agents/bc-55773b13-5f3c-4b4b-b63f-077852b97215/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphoto_scroller.webp)
[Full-screen photo lightbox](https://cursor.com/agents/bc-55773b13-5f3c-4b4b-b63f-077852b97215/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphoto_lightbox.webp)
[Colophon set in Instrument Sans](https://cursor.com/agents/bc-55773b13-5f3c-4b4b-b63f-077852b97215/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcolophon_instrument_sans.webp)

Mobile (390px) software list and lightbox also checked:

[Software list on a 390px viewport](https://cursor.com/agents/bc-55773b13-5f3c-4b4b-b63f-077852b97215/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsoftware_list_mobile.webp)
[Photo lightbox on a 390px viewport](https://cursor.com/agents/bc-55773b13-5f3c-4b4b-b63f-077852b97215/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphoto_lightbox_mobile.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55773b13-5f3c-4b4b-b63f-077852b97215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55773b13-5f3c-4b4b-b63f-077852b97215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

