### PR TITLE
Media strip, fullscreen lightbox, and styled audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -634,7 +634,7 @@
         </main>
     </div>
 
-    <dialog class="photo-lightbox" id="photo-lightbox" aria-modal="true" aria-label="Full-screen photograph">
+    <div class="photo-lightbox" id="photo-lightbox" hidden role="dialog" aria-modal="true" aria-label="Full-screen photograph">
         <div class="photo-lightbox-stage">
             <img class="photo-lightbox-image" src="" alt="">
             <div class="photo-lightbox-hud">
@@ -655,7 +655,7 @@
                 </div>
             </div>
         </div>
-    </dialog>
+    </div>
 
     <!-- Scrollspy Navigator + photography lightbox + audio players -->
     <script>
@@ -680,15 +680,22 @@
 
             sections.forEach(s => observer.observe(s));
 
+            const siteWrapper = document.querySelector('.site-wrapper');
             const photos = Array.from(document.querySelectorAll('.photo-item'));
             const lightbox = document.getElementById('photo-lightbox');
             const lightboxImg = lightbox.querySelector('.photo-lightbox-image');
             const lightboxCap = lightbox.querySelector('.photo-lightbox-caption');
             const lightboxIndex = lightbox.querySelector('.photo-lightbox-index');
+            const lightboxClose = lightbox.querySelector('[data-lightbox-close]');
             let current = 0;
+            let lastFocus = null;
 
             function padIndex(n) {
                 return String(n).padStart(2, '0');
+            }
+
+            function isLightboxOpen() {
+                return lightbox.classList.contains('is-open');
             }
 
             function showPhoto(index) {
@@ -702,33 +709,36 @@
             }
 
             function openPhoto(index) {
+                lastFocus = document.activeElement;
                 showPhoto(index);
-                if (typeof lightbox.showModal === 'function') {
-                    lightbox.showModal();
-                } else {
-                    lightbox.setAttribute('open', '');
-                }
+                lightbox.hidden = false;
+                lightbox.classList.add('is-open');
+                if (siteWrapper) siteWrapper.inert = true;
+                lightboxClose.focus();
             }
 
             function closeLightbox() {
-                if (typeof lightbox.close === 'function' && lightbox.open) {
-                    lightbox.close();
-                } else {
-                    lightbox.removeAttribute('open');
-                }
+                if (!isLightboxOpen()) return;
+                lightbox.classList.remove('is-open');
+                lightbox.hidden = true;
+                if (siteWrapper) siteWrapper.inert = false;
+                if (lastFocus && typeof lastFocus.focus === 'function') lastFocus.focus();
             }
 
             photos.forEach((item, index) => {
                 item.addEventListener('click', () => openPhoto(index));
             });
 
-            lightbox.querySelector('[data-lightbox-close]').addEventListener('click', closeLightbox);
+            lightboxClose.addEventListener('click', closeLightbox);
             lightbox.querySelector('[data-lightbox-prev]').addEventListener('click', () => showPhoto(current - 1));
             lightbox.querySelector('[data-lightbox-next]').addEventListener('click', () => showPhoto(current + 1));
 
             document.addEventListener('keydown', (event) => {
-                if (!lightbox.open) return;
-                if (event.key === 'ArrowLeft') {
+                if (!isLightboxOpen()) return;
+                if (event.key === 'Escape') {
+                    event.preventDefault();
+                    closeLightbox();
+                } else if (event.key === 'ArrowLeft') {
                     event.preventDefault();
                     showPhoto(current - 1);
                 } else if (event.key === 'ArrowRight') {

--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@
                                 <p class="media-card-desc">Steve Reich’s minimalist piece reimagined as danceable down-tempo electronica. Live recording on Novation Launchpad.</p>
                             </div>
                             <div class="audio-player">
-                                <audio preload="none">
+                                <audio preload="metadata">
                                     <source src="https://cdn.maurice-frank.com/morris-media/music/music_for_18_musicians-001.mp3" type="audio/mpeg">
                                 </audio>
                                 <button type="button" class="audio-player-play" aria-label="Play">
@@ -422,7 +422,7 @@
                                 <p class="media-card-desc">Steve Reich’s Piano Phase adapted for electronica and phased synthesizers.</p>
                             </div>
                             <div class="audio-player">
-                                <audio preload="none">
+                                <audio preload="metadata">
                                     <source src="https://cdn.maurice-frank.com/morris-media/music/electronica_piano-phase.mp3" type="audio/mpeg">
                                 </audio>
                                 <button type="button" class="audio-player-play" aria-label="Play">
@@ -443,7 +443,7 @@
                                 <p class="media-card-desc">A gentle chamber waltz composed after watching <em>In the Mood for Love</em>. Scored for Violin, Cello, and Marimba.</p>
                             </div>
                             <div class="audio-player">
-                                <audio preload="none">
+                                <audio preload="metadata">
                                     <source src="https://cdn.maurice-frank.com/morris-media/music/waltz_001.mp3" type="audio/mpeg">
                                 </audio>
                                 <button type="button" class="audio-player-play" aria-label="Play">
@@ -464,7 +464,7 @@
                                 <p class="media-card-desc">An evolving sonic soundscape and ambient synthesis exploration.</p>
                             </div>
                             <div class="audio-player">
-                                <audio preload="none">
+                                <audio preload="metadata">
                                     <source src="https://cdn.maurice-frank.com/morris-media/music/week07.mp3" type="audio/mpeg">
                                 </audio>
                                 <button type="button" class="audio-player-play" aria-label="Play">

--- a/index.html
+++ b/index.html
@@ -358,94 +358,129 @@
                     <span class="section-tag">05 / MEDIA</span>
                 </div>
 
-                <div class="media-cards-grid">
-                    <!-- Video Card: Cats of Istanbul -->
-                    <div class="media-card full-width">
-                        <div class="media-card-top">
-                            <span class="media-card-title">The Cats of Istanbul</span>
-                            <span class="media-card-tag">Video · 2023</span>
-                        </div>
-                        <p class="media-card-desc">Visual vignette capturing street cats in Istanbul (Jan 2023). Music: Altın Gün (<em>Kolbastı</em>). Filmed on Pixel 7, edited in DaVinci Resolve.</p>
-                        <video controls preload="metadata" poster="https://cdn.maurice-frank.com/morris-media/KediIstanbul.jpg">
-                            <source src="https://cdn.maurice-frank.com/morris-media/KediIstanbul.mp4" type="video/mp4">
-                            Your browser does not support HTML5 video.
-                        </video>
-                    </div>
+                <div class="media-subsection">
+                    <div class="nav-label">Video</div>
+                    <div class="media-scroller-wrap">
+                        <div class="video-scroller" role="list" aria-label="Video gallery, scroll sideways">
+                            <article class="video-card" role="listitem">
+                                <div class="media-card-top">
+                                    <span class="media-card-title">The Cats of Istanbul</span>
+                                    <span class="media-card-tag">Video · 2023</span>
+                                </div>
+                                <p class="media-card-desc">Visual vignette capturing street cats in Istanbul (Jan 2023). Music: Altın Gün (<em>Kolbastı</em>). Filmed on Pixel 7, edited in DaVinci Resolve.</p>
+                                <video controls preload="metadata" poster="https://cdn.maurice-frank.com/morris-media/KediIstanbul.jpg">
+                                    <source src="https://cdn.maurice-frank.com/morris-media/KediIstanbul.mp4" type="video/mp4">
+                                    Your browser does not support HTML5 video.
+                                </video>
+                            </article>
 
-                    <!-- Video Card: Eating Hooks -->
-                    <div class="media-card full-width">
-                        <div class="media-card-top">
-                            <span class="media-card-title">Eating Hooks</span>
-                            <span class="media-card-tag">Video · 2020</span>
+                            <article class="video-card" role="listitem">
+                                <div class="media-card-top">
+                                    <span class="media-card-title">Eating Hooks</span>
+                                    <span class="media-card-tag">Video · 2020</span>
+                                </div>
+                                <p class="media-card-desc">Most likely the first high-quality, non-experimental, fully AI-generated music video in this form, dating to 2020.</p>
+                                <video controls preload="metadata" poster="https://cdn.maurice-frank.com/morris-media/Eating%20Hooks.jpg">
+                                    <source src="https://cdn.maurice-frank.com/morris-media/Eating%20Hooks.mp4" type="video/mp4">
+                                    Your browser does not support HTML5 video.
+                                </video>
+                            </article>
                         </div>
-                        <p class="media-card-desc">Most likely the first high-quality, non-experimental, fully AI-generated music video in this form, dating to 2020.</p>
-                        <video controls preload="metadata" poster="https://cdn.maurice-frank.com/morris-media/Eating%20Hooks.jpg">
-                            <source src="https://cdn.maurice-frank.com/morris-media/Eating%20Hooks.mp4" type="video/mp4">
-                            Your browser does not support HTML5 video.
-                        </video>
-                    </div>
-
-                    <!-- Audio: Down-tempo for 18 musicians -->
-                    <div class="media-card">
-                        <div>
-                            <div class="media-card-top">
-                                <span class="media-card-title">Down-tempo for 18 Musicians</span>
-                                <span class="media-card-tag">Audio</span>
-                            </div>
-                            <p class="media-card-desc">Steve Reich’s minimalist piece reimagined as danceable down-tempo electronica. Live recording on Novation Launchpad.</p>
-                        </div>
-                        <audio controls preload="none">
-                            <source src="https://cdn.maurice-frank.com/morris-media/music/music_for_18_musicians-001.mp3" type="audio/mpeg">
-                        </audio>
-                    </div>
-
-                    <!-- Audio: ePiano Phase -->
-                    <div class="media-card">
-                        <div>
-                            <div class="media-card-top">
-                                <span class="media-card-title">ePiano Phase</span>
-                                <span class="media-card-tag">Audio</span>
-                            </div>
-                            <p class="media-card-desc">Steve Reich’s Piano Phase adapted for electronica and phased synthesizers.</p>
-                        </div>
-                        <audio controls preload="none">
-                            <source src="https://cdn.maurice-frank.com/morris-media/music/electronica_piano-phase.mp3" type="audio/mpeg">
-                        </audio>
-                    </div>
-
-                    <!-- Audio: Chow's Theme -->
-                    <div class="media-card">
-                        <div>
-                            <div class="media-card-top">
-                                <span class="media-card-title">Chow’s Theme</span>
-                                <span class="media-card-tag">Chamber</span>
-                            </div>
-                            <p class="media-card-desc">A gentle chamber waltz composed after watching <em>In the Mood for Love</em>. Scored for Violin, Cello, and Marimba.</p>
-                        </div>
-                        <audio controls preload="none">
-                            <source src="https://cdn.maurice-frank.com/morris-media/music/waltz_001.mp3" type="audio/mpeg">
-                        </audio>
-                    </div>
-
-                    <!-- Audio: Metropolitan Mornings -->
-                    <div class="media-card">
-                        <div>
-                            <div class="media-card-top">
-                                <span class="media-card-title">Metropolitan Mornings</span>
-                                <span class="media-card-tag">Soundscape</span>
-                            </div>
-                            <p class="media-card-desc">An evolving sonic soundscape and ambient synthesis exploration.</p>
-                        </div>
-                        <audio controls preload="none">
-                            <source src="https://cdn.maurice-frank.com/morris-media/music/week07.mp3" type="audio/mpeg">
-                        </audio>
                     </div>
                 </div>
 
-                <!-- Photography scroller -->
-                <div style="margin-top: var(--space-xl);">
-                    <div class="nav-label" style="margin-bottom: var(--space-xs);">Photography &amp; Mountains</div>
-                    <div class="photo-scroller-wrap">
+                <div class="media-subsection">
+                    <div class="nav-label">Audio</div>
+                    <div class="media-cards-grid">
+                        <div class="media-card">
+                            <div>
+                                <div class="media-card-top">
+                                    <span class="media-card-title">Down-tempo for 18 Musicians</span>
+                                    <span class="media-card-tag">Audio</span>
+                                </div>
+                                <p class="media-card-desc">Steve Reich’s minimalist piece reimagined as danceable down-tempo electronica. Live recording on Novation Launchpad.</p>
+                            </div>
+                            <div class="audio-player">
+                                <audio preload="none">
+                                    <source src="https://cdn.maurice-frank.com/morris-media/music/music_for_18_musicians-001.mp3" type="audio/mpeg">
+                                </audio>
+                                <button type="button" class="audio-player-play" aria-label="Play">
+                                    <svg class="audio-icon-play" viewBox="0 0 16 16" aria-hidden="true"><path d="M4 2.4v11.2L14 8z"/></svg>
+                                    <svg class="audio-icon-pause" viewBox="0 0 16 16" aria-hidden="true"><path d="M4 3h3v10H4zm5 0h3v10H9z"/></svg>
+                                </button>
+                                <input type="range" class="audio-player-seek" min="0" max="1000" value="0" step="1" aria-label="Seek">
+                                <span class="audio-player-time"><span data-audio-current>0:00</span><span class="audio-player-sep">/</span><span data-audio-duration>0:00</span></span>
+                            </div>
+                        </div>
+
+                        <div class="media-card">
+                            <div>
+                                <div class="media-card-top">
+                                    <span class="media-card-title">ePiano Phase</span>
+                                    <span class="media-card-tag">Audio</span>
+                                </div>
+                                <p class="media-card-desc">Steve Reich’s Piano Phase adapted for electronica and phased synthesizers.</p>
+                            </div>
+                            <div class="audio-player">
+                                <audio preload="none">
+                                    <source src="https://cdn.maurice-frank.com/morris-media/music/electronica_piano-phase.mp3" type="audio/mpeg">
+                                </audio>
+                                <button type="button" class="audio-player-play" aria-label="Play">
+                                    <svg class="audio-icon-play" viewBox="0 0 16 16" aria-hidden="true"><path d="M4 2.4v11.2L14 8z"/></svg>
+                                    <svg class="audio-icon-pause" viewBox="0 0 16 16" aria-hidden="true"><path d="M4 3h3v10H4zm5 0h3v10H9z"/></svg>
+                                </button>
+                                <input type="range" class="audio-player-seek" min="0" max="1000" value="0" step="1" aria-label="Seek">
+                                <span class="audio-player-time"><span data-audio-current>0:00</span><span class="audio-player-sep">/</span><span data-audio-duration>0:00</span></span>
+                            </div>
+                        </div>
+
+                        <div class="media-card">
+                            <div>
+                                <div class="media-card-top">
+                                    <span class="media-card-title">Chow’s Theme</span>
+                                    <span class="media-card-tag">Chamber</span>
+                                </div>
+                                <p class="media-card-desc">A gentle chamber waltz composed after watching <em>In the Mood for Love</em>. Scored for Violin, Cello, and Marimba.</p>
+                            </div>
+                            <div class="audio-player">
+                                <audio preload="none">
+                                    <source src="https://cdn.maurice-frank.com/morris-media/music/waltz_001.mp3" type="audio/mpeg">
+                                </audio>
+                                <button type="button" class="audio-player-play" aria-label="Play">
+                                    <svg class="audio-icon-play" viewBox="0 0 16 16" aria-hidden="true"><path d="M4 2.4v11.2L14 8z"/></svg>
+                                    <svg class="audio-icon-pause" viewBox="0 0 16 16" aria-hidden="true"><path d="M4 3h3v10H4zm5 0h3v10H9z"/></svg>
+                                </button>
+                                <input type="range" class="audio-player-seek" min="0" max="1000" value="0" step="1" aria-label="Seek">
+                                <span class="audio-player-time"><span data-audio-current>0:00</span><span class="audio-player-sep">/</span><span data-audio-duration>0:00</span></span>
+                            </div>
+                        </div>
+
+                        <div class="media-card">
+                            <div>
+                                <div class="media-card-top">
+                                    <span class="media-card-title">Metropolitan Mornings</span>
+                                    <span class="media-card-tag">Soundscape</span>
+                                </div>
+                                <p class="media-card-desc">An evolving sonic soundscape and ambient synthesis exploration.</p>
+                            </div>
+                            <div class="audio-player">
+                                <audio preload="none">
+                                    <source src="https://cdn.maurice-frank.com/morris-media/music/week07.mp3" type="audio/mpeg">
+                                </audio>
+                                <button type="button" class="audio-player-play" aria-label="Play">
+                                    <svg class="audio-icon-play" viewBox="0 0 16 16" aria-hidden="true"><path d="M4 2.4v11.2L14 8z"/></svg>
+                                    <svg class="audio-icon-pause" viewBox="0 0 16 16" aria-hidden="true"><path d="M4 3h3v10H4zm5 0h3v10H9z"/></svg>
+                                </button>
+                                <input type="range" class="audio-player-seek" min="0" max="1000" value="0" step="1" aria-label="Seek">
+                                <span class="audio-player-time"><span data-audio-current>0:00</span><span class="audio-player-sep">/</span><span data-audio-duration>0:00</span></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="media-subsection">
+                    <div class="nav-label">Photography &amp; Mountains</div>
+                    <div class="photo-scroller-wrap media-scroller-wrap">
                         <div class="photo-scroller" id="photo-scroller" role="list" aria-label="Photograph gallery, scroll sideways">
                             <button type="button" class="photo-item" role="listitem" data-caption="Sunrise at Fletschhorn" aria-label="View Sunrise at Fletschhorn full screen">
                                 <img src="https://cdn.maurice-frank.com/morris-media/photography/IMG_20220904_073653-02.webp" alt="Sunrise at Fletschhorn" loading="lazy">
@@ -599,17 +634,30 @@
         </main>
     </div>
 
-    <dialog class="photo-lightbox" id="photo-lightbox" aria-label="Full-screen photograph">
-        <button type="button" class="photo-lightbox-btn photo-lightbox-close" data-lightbox-close aria-label="Close">×</button>
-        <button type="button" class="photo-lightbox-btn photo-lightbox-prev" data-lightbox-prev aria-label="Previous photograph">‹</button>
-        <div class="photo-lightbox-inner">
-            <img src="" alt="">
-            <div class="photo-lightbox-caption"></div>
+    <dialog class="photo-lightbox" id="photo-lightbox" aria-modal="true" aria-label="Full-screen photograph">
+        <div class="photo-lightbox-stage">
+            <img class="photo-lightbox-image" src="" alt="">
+            <div class="photo-lightbox-hud">
+                <div class="photo-lightbox-hud-start">
+                    <button type="button" class="photo-lightbox-btn" data-lightbox-prev aria-label="Previous photograph">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M15 5l-7 7 7 7"/></svg>
+                    </button>
+                    <button type="button" class="photo-lightbox-btn" data-lightbox-next aria-label="Next photograph">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M9 5l7 7-7 7"/></svg>
+                    </button>
+                    <p class="photo-lightbox-caption" aria-live="polite"></p>
+                </div>
+                <div class="photo-lightbox-hud-end">
+                    <span class="photo-lightbox-index"></span>
+                    <button type="button" class="photo-lightbox-btn" data-lightbox-close aria-label="Close">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18"/></svg>
+                    </button>
+                </div>
+            </div>
         </div>
-        <button type="button" class="photo-lightbox-btn photo-lightbox-next" data-lightbox-next aria-label="Next photograph">›</button>
     </dialog>
 
-    <!-- Scrollspy Navigator + photography lightbox -->
+    <!-- Scrollspy Navigator + photography lightbox + audio players -->
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const sections = document.querySelectorAll('.content-section, .colophon-section');
@@ -634,9 +682,14 @@
 
             const photos = Array.from(document.querySelectorAll('.photo-item'));
             const lightbox = document.getElementById('photo-lightbox');
-            const lightboxImg = lightbox.querySelector('img');
+            const lightboxImg = lightbox.querySelector('.photo-lightbox-image');
             const lightboxCap = lightbox.querySelector('.photo-lightbox-caption');
+            const lightboxIndex = lightbox.querySelector('.photo-lightbox-index');
             let current = 0;
+
+            function padIndex(n) {
+                return String(n).padStart(2, '0');
+            }
 
             function showPhoto(index) {
                 current = (index + photos.length) % photos.length;
@@ -645,6 +698,7 @@
                 lightboxImg.src = img.currentSrc || img.src;
                 lightboxImg.alt = img.alt;
                 lightboxCap.textContent = item.dataset.caption || img.alt || '';
+                lightboxIndex.textContent = `${padIndex(current + 1)} / ${padIndex(photos.length)}`;
             }
 
             function openPhoto(index) {
@@ -672,10 +726,6 @@
             lightbox.querySelector('[data-lightbox-prev]').addEventListener('click', () => showPhoto(current - 1));
             lightbox.querySelector('[data-lightbox-next]').addEventListener('click', () => showPhoto(current + 1));
 
-            lightbox.addEventListener('click', (event) => {
-                if (event.target === lightbox) closeLightbox();
-            });
-
             document.addEventListener('keydown', (event) => {
                 if (!lightbox.open) return;
                 if (event.key === 'ArrowLeft') {
@@ -685,6 +735,80 @@
                     event.preventDefault();
                     showPhoto(current + 1);
                 }
+            });
+
+            function formatTime(seconds) {
+                if (!Number.isFinite(seconds) || seconds < 0) return '0:00';
+                const m = Math.floor(seconds / 60);
+                const s = Math.floor(seconds % 60);
+                return `${m}:${String(s).padStart(2, '0')}`;
+            }
+
+            const audioPlayers = Array.from(document.querySelectorAll('.audio-player'));
+
+            audioPlayers.forEach((player) => {
+                const audio = player.querySelector('audio');
+                const playBtn = player.querySelector('.audio-player-play');
+                const seek = player.querySelector('.audio-player-seek');
+                const currentEl = player.querySelector('[data-audio-current]');
+                const durationEl = player.querySelector('[data-audio-duration]');
+                let seeking = false;
+
+                function setProgress(ratio) {
+                    const clamped = Math.min(1, Math.max(0, ratio));
+                    player.style.setProperty('--audio-progress', `${clamped * 100}%`);
+                    seek.value = String(Math.round(clamped * 1000));
+                }
+
+                function syncTime() {
+                    currentEl.textContent = formatTime(audio.currentTime);
+                    const duration = audio.duration;
+                    if (Number.isFinite(duration) && duration > 0) {
+                        durationEl.textContent = formatTime(duration);
+                        if (!seeking) setProgress(audio.currentTime / duration);
+                    }
+                }
+
+                function setPlaying(isPlaying) {
+                    player.classList.toggle('is-playing', isPlaying);
+                    playBtn.setAttribute('aria-label', isPlaying ? 'Pause' : 'Play');
+                }
+
+                playBtn.addEventListener('click', () => {
+                    if (audio.paused) {
+                        audioPlayers.forEach((other) => {
+                            if (other === player) return;
+                            const otherAudio = other.querySelector('audio');
+                            otherAudio.pause();
+                        });
+                        audio.play().catch(() => {});
+                    } else {
+                        audio.pause();
+                    }
+                });
+
+                seek.addEventListener('pointerdown', () => { seeking = true; });
+                seek.addEventListener('pointerup', () => { seeking = false; });
+                seek.addEventListener('input', () => {
+                    const ratio = Number(seek.value) / 1000;
+                    player.style.setProperty('--audio-progress', `${ratio * 100}%`);
+                    if (Number.isFinite(audio.duration) && audio.duration > 0) {
+                        audio.currentTime = ratio * audio.duration;
+                        currentEl.textContent = formatTime(audio.currentTime);
+                    }
+                });
+
+                audio.addEventListener('play', () => setPlaying(true));
+                audio.addEventListener('pause', () => setPlaying(false));
+                audio.addEventListener('ended', () => {
+                    setPlaying(false);
+                    setProgress(0);
+                    audio.currentTime = 0;
+                    currentEl.textContent = formatTime(0);
+                });
+                audio.addEventListener('timeupdate', syncTime);
+                audio.addEventListener('loadedmetadata', syncTime);
+                audio.addEventListener('durationchange', syncTime);
             });
         });
     </script>

--- a/style.css
+++ b/style.css
@@ -535,6 +535,18 @@ body {
 }
 
 /* Playable Media & Audio Cards */
+.media-subsection {
+  margin-top: var(--space-xl);
+}
+
+.section-header + .media-subsection {
+  margin-top: 0;
+}
+
+.media-subsection .nav-label {
+  margin-bottom: var(--space-xs);
+}
+
 .media-cards-grid {
   display: grid;
   grid-template-columns: 1fr;
@@ -547,7 +559,8 @@ body {
   }
 }
 
-.media-card {
+.media-card,
+.video-card {
   background-color: var(--bg-surface);
   border: 1px solid var(--border-hairline);
   border-radius: 4px;
@@ -557,14 +570,11 @@ body {
   justify-content: space-between;
 }
 
-.media-card.full-width {
-  grid-column: 1 / -1;
-}
-
 .media-card-top {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  gap: var(--space-sm);
   margin-bottom: var(--space-2xs);
 }
 
@@ -578,6 +588,7 @@ body {
   font-family: var(--font-mono);
   font-size: 0.7rem;
   color: var(--text-muted);
+  flex-shrink: 0;
 }
 
 .media-card-desc {
@@ -587,32 +598,14 @@ body {
   margin-bottom: var(--space-sm);
 }
 
-/* Audio Player */
-audio {
-  width: 100%;
-  height: 32px;
-  margin-top: var(--space-xs);
-  accent-color: #111111;
-  outline: none;
-}
-
-/* Video Player */
-video {
-  width: 100%;
-  border-radius: 3px;
-  border: 1px solid var(--border-hairline);
-  background: #000000;
-  margin-top: var(--space-xs);
-  display: block;
-}
-
-/* Photography scroller */
-.photo-scroller-wrap {
+/* Horizontal media strips */
+.media-scroller-wrap {
   position: relative;
-  margin-top: var(--space-sm);
+  container-type: inline-size;
+  container-name: media-strip;
 }
 
-.photo-scroller-wrap::after {
+.media-scroller-wrap::after {
   content: "";
   position: absolute;
   top: 0;
@@ -623,34 +616,89 @@ video {
   background: linear-gradient(to right, transparent, var(--bg-app));
 }
 
-.photo-scroller {
-  display: flex;
-  gap: 6px;
+.photo-scroller,
+.video-scroller {
   overflow-x: auto;
   overflow-y: hidden;
+  overscroll-behavior-x: contain;
   scroll-snap-type: x proximity;
-  scroll-padding-inline: 0;
-  padding: 0 0 6px;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: thin;
   scrollbar-color: var(--border-medium) transparent;
 }
 
-.photo-scroller::-webkit-scrollbar {
+.photo-scroller::-webkit-scrollbar,
+.video-scroller::-webkit-scrollbar {
   height: 6px;
 }
 
-.photo-scroller::-webkit-scrollbar-track {
+.photo-scroller::-webkit-scrollbar-track,
+.video-scroller::-webkit-scrollbar-track {
   background: transparent;
 }
 
-.photo-scroller::-webkit-scrollbar-thumb {
+.photo-scroller::-webkit-scrollbar-thumb,
+.video-scroller::-webkit-scrollbar-thumb {
   background: var(--border-medium);
   border-radius: 3px;
 }
 
+.video-scroller {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-md);
+  padding-bottom: 8px;
+}
+
+.video-card {
+  flex: 0 0 auto;
+  width: min(32rem, 82%);
+  scroll-snap-align: start;
+}
+
+.video-card video {
+  --video-h: 13.5rem;
+  width: 100%;
+  height: var(--video-h);
+  margin-top: auto;
+  object-fit: cover;
+  border-radius: 3px;
+  border: 1px solid var(--border-hairline);
+  background: #000000;
+  display: block;
+}
+
+/* Photography: 2 rows, up to 4 on wider strips, then scroll sideways */
+.photo-scroller {
+  --photo-h: 7.5rem;
+  --photo-gap: 6px;
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(2, var(--photo-h));
+  grid-auto-columns: max-content;
+  justify-items: start;
+  align-items: start;
+  gap: var(--photo-gap);
+  box-sizing: content-box;
+  padding-bottom: 10px;
+}
+
+@container media-strip (min-width: 480px) {
+  .photo-scroller {
+    grid-template-rows: repeat(3, var(--photo-h));
+  }
+}
+
+@container media-strip (min-width: 680px) {
+  .photo-scroller {
+    grid-template-rows: repeat(4, var(--photo-h));
+  }
+}
+
 .photo-item {
   flex: 0 0 auto;
+  width: max-content;
+  max-height: var(--photo-h);
   scroll-snap-align: start;
   border: 1px solid var(--border-hairline);
   border-radius: 3px;
@@ -678,107 +726,285 @@ video {
 
 .photo-item img {
   display: block;
-  height: 152px;
+  height: var(--photo-h);
   width: auto;
-  max-width: 240px;
   object-fit: cover;
   transition: opacity 0.15s ease;
 }
 
-/* Full-screen photo lightbox */
-.photo-lightbox {
+/* Custom audio controls */
+.audio-player {
+  --audio-progress: 0%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: var(--space-xs);
+  min-height: 2.25rem;
+}
+
+.audio-player audio {
+  display: none;
+}
+
+.audio-player-play {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 3px;
+  background: var(--text-primary);
+  color: var(--bg-app);
+  cursor: pointer;
+  appearance: none;
+}
+
+.audio-player-play:hover,
+.audio-player-play:focus-visible {
+  background: color-mix(in srgb, var(--text-primary) 82%, white);
+}
+
+.audio-player-play:focus-visible {
+  outline: 2px solid var(--text-primary);
+  outline-offset: 2px;
+}
+
+.audio-player-play svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
+.audio-player-play .audio-icon-pause,
+.audio-player.is-playing .audio-icon-play {
+  display: none;
+}
+
+.audio-player.is-playing .audio-icon-pause {
+  display: block;
+}
+
+.audio-player-seek {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 1.25rem;
+  margin: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  background: linear-gradient(
+    to right,
+    var(--text-primary) 0 var(--audio-progress),
+    var(--border-hairline) var(--audio-progress) 100%
+  );
+  background-size: 100% 2px;
+  background-position: center;
+  background-repeat: no-repeat;
+  accent-color: var(--text-primary);
+  cursor: pointer;
+}
+
+.audio-player-seek:focus-visible {
+  outline: 2px solid var(--text-primary);
+  outline-offset: 3px;
+}
+
+.audio-player-seek::-webkit-slider-runnable-track {
+  height: 2px;
+  background: transparent;
+}
+
+.audio-player-seek::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 11px;
+  height: 11px;
+  margin-top: -4.5px;
+  border: 0;
+  border-radius: 50%;
+  background: var(--text-primary);
+}
+
+.audio-player-seek::slider-track {
+  background: transparent;
+  height: 2px;
+}
+
+.audio-player-seek::slider-fill {
+  background: var(--text-primary);
+  height: 2px;
+}
+
+.audio-player-seek::slider-thumb {
+  appearance: none;
+  width: 11px;
+  height: 11px;
+  border: 0;
+  border-radius: 50%;
+  background: var(--text-primary);
+}
+
+.audio-player-time {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  color: var(--text-muted);
+  min-width: 5.6em;
+  text-align: right;
+}
+
+.audio-player-sep {
+  margin: 0 0.2em;
+  color: var(--text-faint);
+}
+
+/* Full-screen photo lightbox — edge-to-edge, chrome over the image */
+html:has(.photo-lightbox[open]) {
+  overflow: hidden;
+}
+
+.photo-lightbox,
+.photo-lightbox:modal {
   position: fixed;
   inset: 0;
+  width: 100%;
+  height: 100%;
+  height: 100dvh;
+  max-width: none;
+  max-height: none;
   margin: 0;
-  border: none;
   padding: 0;
-  width: 100vw;
-  height: 100vh;
-  max-width: 100vw;
-  max-height: 100vh;
-  background: rgba(10, 10, 10, 0.96);
-  color: #f5f5f5;
+  border: none;
+  background: #000;
+  color: #fff;
+  overflow: hidden;
 }
 
 .photo-lightbox::backdrop {
-  background: rgba(0, 0, 0, 0.92);
+  background: #000;
 }
 
-.photo-lightbox-inner {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+.photo-lightbox-stage {
+  position: absolute;
+  inset: 0;
+}
+
+.photo-lightbox-image {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
-  padding: 48px 56px 40px;
-  box-sizing: border-box;
-}
-
-.photo-lightbox img {
-  width: auto;
-  height: auto;
-  max-width: min(96vw, 1400px);
-  max-height: calc(100vh - 96px);
+  max-width: none;
+  max-height: none;
+  margin: 0;
   object-fit: contain;
+  background: #000;
   border: none;
   border-radius: 0;
-  background: transparent;
-  margin: 0;
+}
+
+.photo-lightbox-hud {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 56px;
+  background: linear-gradient(
+    to bottom,
+    rgb(0 0 0 / 0.72) 0%,
+    rgb(0 0 0 / 0.32) 58%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+
+.photo-lightbox-hud-start,
+.photo-lightbox-hud-end {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  pointer-events: auto;
+}
+
+.photo-lightbox-hud-end {
+  flex-shrink: 0;
 }
 
 .photo-lightbox-caption {
-  margin-top: 12px;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  color: rgba(255, 255, 255, 0.72);
-  min-height: 1.2em;
+  margin: 0;
+  padding: 0 4px;
+  font-size: 0.92rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.photo-lightbox-index {
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(255 255 255 / 0.58);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .photo-lightbox-btn {
-  position: absolute;
   appearance: none;
-  -webkit-appearance: none;
-  background: transparent;
-  border: none;
-  color: rgba(255, 255, 255, 0.7);
+  display: grid;
+  place-items: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  padding: 0;
+  border: 1px solid rgb(255 255 255 / 0.38);
+  border-radius: 3px;
+  background: rgb(0 0 0 / 0.38);
+  color: #fff;
   cursor: pointer;
-  font: inherit;
-  line-height: 1;
-  padding: 8px;
-  transition: color 0.15s ease, background 0.15s ease;
+  backdrop-filter: blur(14px) saturate(1.2);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.photo-lightbox-btn svg {
+  width: 16px;
+  height: 16px;
+  stroke-linecap: square;
 }
 
 .photo-lightbox-btn:hover,
 .photo-lightbox-btn:focus-visible {
-  color: #ffffff;
+  background: rgb(255 255 255 / 0.16);
+  border-color: #fff;
 }
 
-.photo-lightbox-close {
-  top: 12px;
-  right: 16px;
-  font-size: 1.5rem;
+.photo-lightbox-btn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
 }
-
-.photo-lightbox-prev,
-.photo-lightbox-next {
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: 2rem;
-  padding: 16px 12px;
-}
-
-.photo-lightbox-prev { left: 4px; }
-.photo-lightbox-next { right: 4px; }
 
 @media (max-width: 600px) {
-  .photo-lightbox-inner {
-    padding: 40px 12px 32px;
+  .photo-lightbox-hud {
+    padding: calc(10px + env(safe-area-inset-top, 0px)) 10px 48px;
+    gap: 8px;
   }
-  .photo-lightbox-prev,
-  .photo-lightbox-next {
-    font-size: 1.5rem;
-    padding: 12px 6px;
+  .photo-lightbox-caption {
+    font-size: 0.82rem;
+  }
+  .photo-lightbox-index {
+    display: none;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -652,7 +652,7 @@ body {
 
 .video-card {
   flex: 0 0 auto;
-  width: min(32rem, 82%);
+  width: min(26rem, 78%);
   scroll-snap-align: start;
 }
 
@@ -862,29 +862,37 @@ body {
 }
 
 /* Full-screen photo lightbox — edge-to-edge, chrome over the image */
-html:has(.photo-lightbox[open]) {
+html:has(.photo-lightbox.is-open) {
   overflow: hidden;
 }
 
-.photo-lightbox,
-.photo-lightbox:modal {
+.photo-lightbox {
+  display: none;
   position: fixed;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9999;
+  width: 100vw;
+  height: 100vh;
   height: 100dvh;
   max-width: none;
   max-height: none;
   margin: 0;
   padding: 0;
-  border: none;
+  border: 0;
   background: #000;
   color: #fff;
   overflow: hidden;
 }
 
-.photo-lightbox::backdrop {
-  background: #000;
+.photo-lightbox.is-open {
+  display: block;
+}
+
+.photo-lightbox[hidden] {
+  display: none !important;
 }
 
 .photo-lightbox-stage {

--- a/style.css
+++ b/style.css
@@ -623,23 +623,23 @@ body {
   overscroll-behavior-x: contain;
   scroll-snap-type: x proximity;
   -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-medium) transparent;
+  scrollbar-width: auto;
+  scrollbar-color: var(--text-muted) var(--bg-subtle);
 }
 
 .photo-scroller::-webkit-scrollbar,
 .video-scroller::-webkit-scrollbar {
-  height: 6px;
+  height: 10px;
 }
 
 .photo-scroller::-webkit-scrollbar-track,
 .video-scroller::-webkit-scrollbar-track {
-  background: transparent;
+  background: var(--bg-subtle);
 }
 
 .photo-scroller::-webkit-scrollbar-thumb,
 .video-scroller::-webkit-scrollbar-thumb {
-  background: var(--border-medium);
+  background: var(--text-faint);
   border-radius: 3px;
 }
 

--- a/style.css
+++ b/style.css
@@ -652,7 +652,7 @@ body {
 
 .video-card {
   flex: 0 0 auto;
-  width: min(26rem, 78%);
+  width: min(34rem, 86%);
   scroll-snap-align: start;
 }
 
@@ -923,12 +923,12 @@ html:has(.photo-lightbox.is-open) {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 56px;
+  gap: 16px;
+  padding: calc(18px + env(safe-area-inset-top, 0px)) 20px 72px;
   background: linear-gradient(
     to bottom,
-    rgb(0 0 0 / 0.72) 0%,
-    rgb(0 0 0 / 0.32) 58%,
+    rgb(0 0 0 / 0.78) 0%,
+    rgb(0 0 0 / 0.36) 52%,
     transparent 100%
   );
   pointer-events: none;
@@ -949,10 +949,10 @@ html:has(.photo-lightbox.is-open) {
 
 .photo-lightbox-caption {
   margin: 0;
-  padding: 0 4px;
-  font-size: 0.92rem;
+  padding: 0 8px;
+  font-size: 1.05rem;
   font-weight: 500;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.015em;
   line-height: 1.3;
   color: #fff;
   white-space: nowrap;
@@ -974,21 +974,21 @@ html:has(.photo-lightbox.is-open) {
   appearance: none;
   display: grid;
   place-items: center;
-  width: 2.35rem;
-  height: 2.35rem;
+  width: 2.75rem;
+  height: 2.75rem;
   padding: 0;
-  border: 1px solid rgb(255 255 255 / 0.38);
-  border-radius: 3px;
-  background: rgb(0 0 0 / 0.38);
+  border: 1px solid rgb(255 255 255 / 0.45);
+  border-radius: 4px;
+  background: rgb(0 0 0 / 0.45);
   color: #fff;
   cursor: pointer;
-  backdrop-filter: blur(14px) saturate(1.2);
+  backdrop-filter: blur(16px) saturate(1.4);
   transition: background 0.15s ease, border-color 0.15s ease;
 }
 
 .photo-lightbox-btn svg {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   stroke-linecap: square;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Photos stay two to four rows tall and overflow sideways instead of growing the page. Videos use the same horizontal-scroll pattern at a shared height. The photograph viewer is a fixed, edge-to-edge overlay (not a native `dialog`, which kept UA gutters): prev/next, caption, index, and close sit on a top HUD over the image, and the photograph is `object-fit: contain` so it never spills the viewport. Native audio controls are replaced with a play/seek/time UI painted to the monochrome hairline system.

## What changed

- Photography: CSS grid `auto-flow: column`, 2 rows by default, 3 then 4 as the strip widens, horizontal scroll
- Video: side-by-side scroller, equal `13.5rem` player height
- Lightbox: viewport-covering overlay; HUD over the image
- Audio: custom player (play/pause, range, `0:00 / 0:00`) using `accent-color`, `color-mix`, `::slider-*`, and a progress custom property

## How to check

1. Open `#media` on a desktop-width content column — photos should show four rows and scroll sideways
2. Narrow the window — photos drop to two rows, still horizontal
3. Click a photo — fullscreen black, image contained, caption + buttons on top
4. Arrow keys / prev-next, Esc to close
5. Scroll the two videos; both players should share height
6. Play an audio card; controls should match the page, and starting another track should pause the first
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34024f8e-7cae-4982-b813-869f050593c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

