### PR TITLE
Add system-preference dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
     <title>Maurice Frank — CTO & AI Engineer</title>
     <meta name="description" content="Maurice Frank is a CTO, founding engineer, and AI/data specialist building platforms for bioinformatics, agriculture, and intelligent applications.">
     <link rel="icon" href="favicon.ico">
@@ -133,7 +134,7 @@
                         <div>
                             <div class="card-item-header">
                                 <span class="card-item-brand">
-                                    <img class="card-item-logo is-wordmark" src="logos/muno.svg" alt="Muno" width="104" height="28">
+                                    <img class="card-item-logo is-wordmark is-ink" src="logos/muno.svg" alt="Muno" width="104" height="28">
                                 </span>
                                 <span class="card-item-date">2024 — Present</span>
                             </div>

--- a/maps/index.html
+++ b/maps/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
     <title>Maps — Alpine tracks — Maurice Frank</title>
     <meta name="description" content="Slippy-tile map of alpine mountaineering tracks from Hikr and personal Bergrebell tours.">
     <link rel="icon" href="../favicon.ico">

--- a/maps/maps.css
+++ b/maps/maps.css
@@ -59,7 +59,7 @@ html, body {
   font-family: var(--font-mono);
   font-size: 0.62rem;
   letter-spacing: 0.02em;
-  background: rgba(255, 255, 255, 0.88) !important;
+  background: var(--bg-overlay) !important;
   color: var(--text-muted);
   padding: 3px 8px !important;
   border-top: 1px solid var(--border-hairline);

--- a/motion-stills/index.html
+++ b/motion-stills/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
     <title>Motion stills — Maurice Frank</title>
     <meta name="description" content="A collection of stabilized Motion Stills — short looping videos made with Google's MotionStills app.">
     <link rel="icon" href="../favicon.ico">

--- a/motion-stills/motion-stills.css
+++ b/motion-stills/motion-stills.css
@@ -23,7 +23,7 @@ body {
   position: sticky;
   top: 0;
   z-index: 20;
-  background: rgba(255, 255, 255, 0.92);
+  background: var(--bg-overlay);
   backdrop-filter: blur(10px);
   border-bottom: 1px solid var(--border-strong);
 }

--- a/soilytix/index.html
+++ b/soilytix/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
     <title>Soilytix workshop — Maurice Frank</title>
     <meta name="description" content="Overview of Soilytix workshop artifacts: architecture maps, product mocks, domain comics, and internal research.">
     <link rel="icon" href="../favicon.ico">

--- a/style.css
+++ b/style.css
@@ -19,6 +19,7 @@ html {
   scroll-padding-top: var(--space-xl);
   font-size: 16px;
   -webkit-text-size-adjust: 100%;
+  color-scheme: light dark;
 }
 
 body {
@@ -331,7 +332,7 @@ body {
 
 .card-item:hover {
   border-color: var(--text-primary);
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
+  box-shadow: var(--shadow-card);
 }
 
 .card-item-header {
@@ -369,6 +370,12 @@ body {
 .card-item-logo.is-wide {
   height: 1.7rem;
   max-width: 9.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card-item-logo.is-ink {
+    filter: invert(1);
+  }
 }
 
 .card-item-title {
@@ -1096,6 +1103,17 @@ html:has(.photo-lightbox.is-open) {
 
 /* Print */
 @media print {
+  :root {
+    color-scheme: light;
+    --bg-app: #FFFFFF;
+    --bg-subtle: #F8F9FA;
+    --bg-surface: #FFFFFF;
+    --text-primary: #111111;
+    --text-secondary: #4A4A4A;
+    --text-muted: #767676;
+    --border-hairline: #E5E7EB;
+    --border-strong: #111111;
+  }
   body {
     background: #FFFFFF;
     color: #000000;

--- a/tokens.css
+++ b/tokens.css
@@ -1,10 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap');
 
 :root {
+  color-scheme: light;
   --bg-app: #FFFFFF;
   --bg-subtle: #F8F9FA;
   --bg-surface: #FFFFFF;
   --bg-hover: #F1F3F5;
+  --bg-overlay: rgb(255 255 255 / 0.92);
 
   --text-primary: #111111;
   --text-secondary: #4A4A4A;
@@ -14,6 +16,8 @@
   --border-hairline: #E5E7EB;
   --border-medium: #D1D5DB;
   --border-strong: #111111;
+
+  --shadow-card: 0 2px 10px rgb(0 0 0 / 0.04);
 
   --font-sans: "Instrument Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-mono: var(--font-sans);
@@ -30,4 +34,26 @@
   --space-3xl: 5rem;
 
   --transition-fast: all 0.15s ease;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --bg-app: #0C0C0C;
+    --bg-subtle: #161616;
+    --bg-surface: #141414;
+    --bg-hover: #1F1F1F;
+    --bg-overlay: rgb(12 12 12 / 0.92);
+
+    --text-primary: #F2F2F2;
+    --text-secondary: #B8B8B8;
+    --text-muted: #8C8C8C;
+    --text-faint: #6A6A6A;
+
+    --border-hairline: #2A2A2A;
+    --border-medium: #3D3D3D;
+    --border-strong: #F2F2F2;
+
+    --shadow-card: 0 2px 12px rgb(0 0 0 / 0.45);
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Dark mode follows the OS preference (`prefers-color-scheme`). No in-page toggle.

Shared tokens in `tokens.css` invert the monochrome palette (backgrounds, text, borders, card shadow, translucent overlays). Pages that already use those tokens pick this up: homepage, Soilytix workshop index, maps, and motion stills.

The Muno wordmark is an SVG served as an image, so it is inverted in dark mode to stay ink-on-surface. Colored marks (Soilytix, peau.ai, Hummingbird) are unchanged. The photo lightbox stays black. Print stays light.

`<meta name="color-scheme" content="light dark">` and `color-scheme` on `:root` let native controls (scrollbars, video chrome) follow the same preference.

[Homepage in light mode](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr2-home-light.png)
[Homepage in dark mode](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr2-home-dark.png)
[Venture cards in dark mode](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr2-ventures-dark.png)
[Audio players in dark mode](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr2-audio-dark.png)
[Colophon in dark mode with active nav](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr2-colophon-dark.png)
[Maps overlay in dark mode](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr2-maps-dark.png)
[Motion stills in dark mode](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr2-motion-stills-dark.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34024f8e-7cae-4982-b813-869f050593c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

