### PR TITLE
oklch colors, 16:9 videos, Hyperlegible, CV dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
                                     <img class="card-item-logo is-mark" src="logos/peau.png" alt="" width="32" height="32">
                                     <span class="card-item-title">peau.ai</span>
                                 </span>
-                                <span class="card-item-date">2025 — Present</span>
+                                <span class="card-item-date">2025 — 2026</span>
                             </div>
                             <div class="card-item-role">Founding Engineer</div>
                             <p class="card-item-desc">
@@ -136,7 +136,7 @@
                                 <span class="card-item-brand">
                                     <img class="card-item-logo is-wordmark is-ink" src="logos/muno.svg" alt="Muno" width="104" height="28">
                                 </span>
-                                <span class="card-item-date">2024 — Present</span>
+                                <span class="card-item-date">2024 — 2026</span>
                             </div>
                             <div class="card-item-role">Founding Engineer</div>
                             <p class="card-item-desc">
@@ -174,18 +174,23 @@
                 <table class="cv-table">
                     <tbody>
                         <tr>
-                            <td class="cv-date-col">2025 — Present</td>
+                            <td class="cv-date-col">2026 — Present</td>
+                            <td class="cv-title-col"><a href="https://soilytix.com/" target="_blank" rel="noopener noreferrer">Soilytix</a> — CTO</td>
+                            <td class="cv-detail-col">Soil Intelligence / Next.js</td>
+                        </tr>
+                        <tr>
+                            <td class="cv-date-col">2025 — 2026</td>
                             <td class="cv-title-col"><a href="https://peau.ai/" target="_blank" rel="noopener noreferrer">peau.ai</a> — Founding Engineer</td>
                             <td class="cv-detail-col">Skincare AI / Flutter / Firebase</td>
                         </tr>
                         <tr>
-                            <td class="cv-date-col">2024 — Present</td>
+                            <td class="cv-date-col">2024 — 2026</td>
                             <td class="cv-title-col"><a href="https://muno.ai/" target="_blank" rel="noopener noreferrer">Muno</a> — Founding Engineer</td>
                             <td class="cv-detail-col">Immune Health / RNA-Seq</td>
                         </tr>
                         <tr>
                             <td class="cv-date-col">2023 — Present</td>
-                            <td class="cv-title-col"><a href="https://soilytix.com/" target="_blank" rel="noopener noreferrer">Soilytix</a> — CTO & Founding Engineer</td>
+                            <td class="cv-title-col"><a href="https://soilytix.com/" target="_blank" rel="noopener noreferrer">Soilytix</a> — Founding Engineer</td>
                             <td class="cv-detail-col">Soil Intelligence / Next.js</td>
                         </tr>
                         <tr>
@@ -616,7 +621,7 @@
                 </div>
 
                 <p style="margin-bottom: var(--space-md);">
-                    Set in <em>Instrument Sans</em>. Built with zero tracking, zero cookies, and zero analytics.
+                    Set in <em>Atkinson Hyperlegible</em>. Built with zero tracking, zero cookies, and zero analytics.
                 </p>
 
                 <div class="colophon-legal">

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
   Maurice Frank — Design System & Styles
   Aesthetic: Swiss Minimalist UI + Structured Editorial UX
-  Typography: Instrument Sans
+  Typography: Atkinson Hyperlegible
   Palette: Pure monochrome, crisp hairline geometry, high-density clarity
 */
 
@@ -702,14 +702,14 @@ a.card-item:hover .card-item-title {
 }
 
 .video-card video {
-  --video-h: 13.5rem;
   width: 100%;
-  height: var(--video-h);
+  height: auto;
+  aspect-ratio: 16 / 9;
   margin-top: auto;
-  object-fit: cover;
+  object-fit: contain;
   border-radius: 3px;
   border: 1px solid var(--border-hairline);
-  background: #000000;
+  background: oklch(0 0 0);
   display: block;
 }
 
@@ -744,8 +744,8 @@ a.card-item:hover .card-item-title {
   width: max-content;
   max-height: var(--photo-h);
   scroll-snap-align: start;
-  border: 1px solid var(--border-hairline);
-  border-radius: 3px;
+  border: 0;
+  border-radius: 0;
   overflow: hidden;
   background: var(--bg-subtle);
   padding: 0;
@@ -926,8 +926,8 @@ html:has(.photo-lightbox.is-open) {
   margin: 0;
   padding: 0;
   border: 0;
-  background: #000;
-  color: #fff;
+  background: oklch(0 0 0);
+  color: oklch(1 0 0);
   overflow: hidden;
 }
 
@@ -953,7 +953,7 @@ html:has(.photo-lightbox.is-open) {
   max-height: none;
   margin: 0;
   object-fit: contain;
-  background: #000;
+  background: oklch(0 0 0);
   border: none;
   border-radius: 0;
 }
@@ -971,8 +971,8 @@ html:has(.photo-lightbox.is-open) {
   padding: calc(18px + env(safe-area-inset-top, 0px)) 20px 72px;
   background: linear-gradient(
     to bottom,
-    rgb(0 0 0 / 0.78) 0%,
-    rgb(0 0 0 / 0.36) 52%,
+    oklch(0 0 0 / 0.78) 0%,
+    oklch(0 0 0 / 0.36) 52%,
     transparent 100%
   );
   pointer-events: none;
@@ -998,7 +998,7 @@ html:has(.photo-lightbox.is-open) {
   font-weight: 500;
   letter-spacing: -0.015em;
   line-height: 1.3;
-  color: #fff;
+  color: oklch(1 0 0);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1009,7 +1009,7 @@ html:has(.photo-lightbox.is-open) {
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgb(255 255 255 / 0.58);
+  color: oklch(1 0 0 / 0.58);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -1021,10 +1021,10 @@ html:has(.photo-lightbox.is-open) {
   width: 2.75rem;
   height: 2.75rem;
   padding: 0;
-  border: 1px solid rgb(255 255 255 / 0.45);
+  border: 1px solid oklch(1 0 0 / 0.45);
   border-radius: 4px;
-  background: rgb(0 0 0 / 0.45);
-  color: #fff;
+  background: oklch(0 0 0 / 0.45);
+  color: oklch(1 0 0);
   cursor: pointer;
   backdrop-filter: blur(16px) saturate(1.4);
   transition: background 0.15s ease, border-color 0.15s ease;
@@ -1038,12 +1038,12 @@ html:has(.photo-lightbox.is-open) {
 
 .photo-lightbox-btn:hover,
 .photo-lightbox-btn:focus-visible {
-  background: rgb(255 255 255 / 0.16);
-  border-color: #fff;
+  background: oklch(1 0 0 / 0.16);
+  border-color: oklch(1 0 0);
 }
 
 .photo-lightbox-btn:focus-visible {
-  outline: 2px solid #fff;
+  outline: 2px solid oklch(1 0 0);
   outline-offset: 2px;
 }
 
@@ -1105,18 +1105,18 @@ html:has(.photo-lightbox.is-open) {
 @media print {
   :root {
     color-scheme: light;
-    --bg-app: #FFFFFF;
-    --bg-subtle: #F8F9FA;
-    --bg-surface: #FFFFFF;
-    --text-primary: #111111;
-    --text-secondary: #4A4A4A;
-    --text-muted: #767676;
-    --border-hairline: #E5E7EB;
-    --border-strong: #111111;
+    --bg-app: oklch(1 0 0);
+    --bg-subtle: oklch(0.982 0.0017 248);
+    --bg-surface: oklch(1 0 0);
+    --text-primary: oklch(0.178 0 0);
+    --text-secondary: oklch(0.409 0 0);
+    --text-muted: oklch(0.566 0 0);
+    --border-hairline: oklch(0.928 0.0058 265);
+    --border-strong: oklch(0.178 0 0);
   }
   body {
-    background: #FFFFFF;
-    color: #000000;
+    background: oklch(1 0 0);
+    color: oklch(0 0 0);
   }
   .site-sidebar {
     position: static;

--- a/tokens.css
+++ b/tokens.css
@@ -1,25 +1,25 @@
-@import url('https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&display=swap');
 
 :root {
   color-scheme: light;
-  --bg-app: #FFFFFF;
-  --bg-subtle: #F8F9FA;
-  --bg-surface: #FFFFFF;
-  --bg-hover: #F1F3F5;
-  --bg-overlay: rgb(255 255 255 / 0.92);
+  --bg-app: oklch(1 0 0);
+  --bg-subtle: oklch(0.982 0.0017 248);
+  --bg-surface: oklch(1 0 0);
+  --bg-hover: oklch(0.963 0.0034 248);
+  --bg-overlay: oklch(1 0 0 / 0.92);
 
-  --text-primary: #111111;
-  --text-secondary: #4A4A4A;
-  --text-muted: #767676;
-  --text-faint: #9E9E9E;
+  --text-primary: oklch(0.178 0 0);
+  --text-secondary: oklch(0.409 0 0);
+  --text-muted: oklch(0.566 0 0);
+  --text-faint: oklch(0.699 0 0);
 
-  --border-hairline: #E5E7EB;
-  --border-medium: #D1D5DB;
-  --border-strong: #111111;
+  --border-hairline: oklch(0.928 0.0058 265);
+  --border-medium: oklch(0.872 0.0093 258);
+  --border-strong: oklch(0.178 0 0);
 
-  --shadow-card: 0 2px 10px rgb(0 0 0 / 0.04);
+  --shadow-card: 0 2px 10px oklch(0 0 0 / 0.04);
 
-  --font-sans: "Instrument Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-sans: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-mono: var(--font-sans);
 
   --sidebar-width: 280px;
@@ -39,21 +39,21 @@
 @media (prefers-color-scheme: dark) {
   :root {
     color-scheme: dark;
-    --bg-app: #0C0C0C;
-    --bg-subtle: #161616;
-    --bg-surface: #141414;
-    --bg-hover: #1F1F1F;
-    --bg-overlay: rgb(12 12 12 / 0.92);
+    --bg-app: oklch(0.21 0 0);
+    --bg-subtle: oklch(0.256 0 0);
+    --bg-surface: oklch(0.247 0 0);
+    --bg-hover: oklch(0.295 0 0);
+    --bg-overlay: oklch(0.21 0 0 / 0.92);
 
-    --text-primary: #F2F2F2;
-    --text-secondary: #B8B8B8;
-    --text-muted: #8C8C8C;
-    --text-faint: #6A6A6A;
+    --text-primary: oklch(0.961 0 0);
+    --text-secondary: oklch(0.783 0 0);
+    --text-muted: oklch(0.640 0 0);
+    --text-faint: oklch(0.524 0 0);
 
-    --border-hairline: #2A2A2A;
-    --border-medium: #3D3D3D;
-    --border-strong: #F2F2F2;
+    --border-hairline: oklch(0.341 0 0);
+    --border-medium: oklch(0.416 0 0);
+    --border-strong: oklch(0.961 0 0);
 
-    --shadow-card: 0 2px 12px rgb(0 0 0 / 0.45);
+    --shadow-card: 0 2px 12px oklch(0 0 0 / 0.45);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Visual and CV polish on the homepage.

- Design tokens and site chrome colors are expressed as `oklch`. Dark mode page background is `oklch(0.21 0 0)`.
- Video previews use a 16:9 frame (`aspect-ratio: 16 / 9`, `object-fit: contain`) instead of a cropped short strip.
- Photo thumbnails have no border and no rounded corners.
- CV: Soilytix CTO is a separate top row from 2026; founding engineer remains 2023–present. peau.ai and Muno end in 2026.
- Typeface is Atkinson Hyperlegible (colophon updated).

[Homepage light, Atkinson Hyperlegible](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr3-home-light.png)
[Homepage dark at oklch lightness 0.21](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr3-home-dark.png)
[CV with split Soilytix roles](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr3-cv.png)
[16:9 video preview](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr3-video.png)
[Photo thumbnails without border or radius](https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr3-photos.png)

Static HTML/CSS only.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34024f8e-7cae-4982-b813-869f050593c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34024f8e-7cae-4982-b813-869f050593c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

